### PR TITLE
Fix segmentation during file open

### DIFF
--- a/highlighter.cpp
+++ b/highlighter.cpp
@@ -159,7 +159,10 @@ Highlighter::Highlighter(const QString _filename, QObject *parent) : QSyntaxHigh
 }
 
 void Highlighter::highlightBlock(const QString& text) {
-    auto &data = langs.value(current_extension);
+    // Retrieve the highlighting data for the current extension. `QHash::value`
+    // returns the value by copy, so storing it by reference would leave us with
+    // a dangling reference. Keep the value locally instead.
+    auto data = langs.value(current_extension);
 
 
     foreach (const HighlightFormat& rule_, data.for_keywords) {

--- a/kamakura.cpp
+++ b/kamakura.cpp
@@ -469,7 +469,7 @@ void kamakura::CloseFile() {
         CloseFile(tabs->currentIndex());
 }
 
-void::kamakura::UpdateParameter() {
+void kamakura::UpdateParameter() {
 
         QString file = tabs->tabBar()->tabText(tabs->currentIndex());
         QString file_extension = QFileInfo(file).suffix();


### PR DESCRIPTION
## Summary
- avoid dangling reference in `Highlighter::highlightBlock`
- fix spelling of `UpdateParameter` method definition

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b309779c832dab7080912e4cbf4b