### PR TITLE
Fix syntax highlighting

### DIFF
--- a/kamakura.cpp
+++ b/kamakura.cpp
@@ -240,8 +240,9 @@ void kamakura::onCurrentTabChanged(int index)
 
     CodeEditor* editor = currentEditor();
     if (!editor) return;
-    
+
     QFileInfo fileInfo(tabs->tabToolTip(index));
+    highlighter->setDocument(editor->document());
     highlighter->setExtension(fileInfo.suffix());
     highlighter->rehighlight();
 


### PR DESCRIPTION
## Summary
- connect highlighter to the current document when switching tabs so highlighting works

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cd10f2a4832da578181036af39eb