### PR TITLE
Fix build errors

### DIFF
--- a/codeeditor.cpp
+++ b/codeeditor.cpp
@@ -186,6 +186,12 @@ void CodeEditor::replaceAll(QString what, QString with, bool caseSensitive, bool
     connect(this, SIGNAL(textChanged()), this, SLOT(on_textChanged()));
 }
 
+void CodeEditor::updateMetrics()
+{
+    handleTextChanged();
+    handleCursorPositionChanged();
+}
+
 
 void CodeEditor::moveCursorTo(int positionInText)
 {

--- a/codeeditor.h
+++ b/codeeditor.h
@@ -59,6 +59,7 @@ public slots:
     bool find(QString query, bool caseSensitive, bool wholeWords);
     void replace(QString what, QString with, bool caseSensitive, bool wholeWords);
     void replaceAll(QString what, QString with, bool caseSensitive, bool wholeWords);
+    void updateMetrics();
 
 private:
     QWidget *lineNumberArea;

--- a/kamakura.cpp
+++ b/kamakura.cpp
@@ -12,7 +12,6 @@
 #include <QMenu>
 #include <QMimeData>
 #include <QDebug>
-#include <QCompleter>
 #include <QStringListModel>
 #include <QCoreApplication>
 
@@ -246,9 +245,6 @@ void kamakura::onCurrentTabChanged(int index)
     highlighter->setExtension(fileInfo.suffix());
     highlighter->rehighlight();
 
-    QStringList keywords = highlighter->getKeywordsForExtension(fileInfo.suffix());
-    QCompleter *completer = new QCompleter(keywords, this);
-    editor->setCompleter(completer);
     
     disconnect(findDialog, &FindDialog::startFinding, nullptr, nullptr);
     disconnect(findDialog, &FindDialog::startReplacing, nullptr, nullptr);
@@ -260,8 +256,15 @@ void kamakura::onCurrentTabChanged(int index)
     connect(findDialog, &FindDialog::startReplacingAll, editor, &CodeEditor::replaceAll);
     connect(editor, &CodeEditor::findResultReady, findDialog, &FindDialog::onFindResultReady);
 
-    disconnect(editor, &CodeEditor::metricsChanged, nullptr, nullptr); 
-    connect(editor, &CodeEditor::metricsChanged, metricReporter, &MetricReporter::updateMetrics);
+    disconnect(editor, &CodeEditor::wordCountChanged, nullptr, nullptr);
+    disconnect(editor, &CodeEditor::charCountChanged, nullptr, nullptr);
+    disconnect(editor, &CodeEditor::lineChanged, nullptr, nullptr);
+    disconnect(editor, &CodeEditor::columnChanged, nullptr, nullptr);
+
+    connect(editor, &CodeEditor::wordCountChanged, metricReporter, &MetricReporter::updateWordCount);
+    connect(editor, &CodeEditor::charCountChanged, metricReporter, &MetricReporter::updateCharCount);
+    connect(editor, &CodeEditor::lineChanged, metricReporter, &MetricReporter::updateLineCount);
+    connect(editor, &CodeEditor::columnChanged, metricReporter, &MetricReporter::updateColumnCount);
     
     editor->updateMetrics(); 
     updateWindowTitle(tabs->tabToolTip(index));

--- a/metrics.cpp
+++ b/metrics.cpp
@@ -47,4 +47,12 @@ void MetricReporter::updateColumnCount(int columnCount)
 {
     columnCountLabel->setText(QString::number(columnCount));
 }
+
+void MetricReporter::clearMetrics()
+{
+    wordCountLabel->clear();
+    charCountLabel->clear();
+    lineCountLabel->clear();
+    columnCountLabel->clear();
+}
 //Kamakura-- Mehrdad S. Beni and Hiroshi Watabe, Japan 2023

--- a/metrics.h
+++ b/metrics.h
@@ -20,6 +20,7 @@ public slots:
     void updateCharCount(int charCount);
     void updateLineCount(int current, int total);
     void updateColumnCount(int columnCount);
+    void clearMetrics();
 
 private:
     QLabel *wordLabel;


### PR DESCRIPTION
## Summary
- add missing `clearMetrics` slot
- allow `CodeEditor` to update metrics
- remove unimplemented code completion calls
- wire metric signals directly in `kamakura.cpp`

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ce206980832da9494e73e48e997b