### PR TITLE
Fix highlighter initialization for first opened file

### DIFF
--- a/kamakura.cpp
+++ b/kamakura.cpp
@@ -99,6 +99,9 @@ void kamakura::on_actionNew_triggered()
 
     opened_docs_widget->addItem("Untitled");
     syncListSelectionWithTab(index);
+
+    // Ensure highlighter is set even if the currentChanged signal isn't emitted
+    onCurrentTabChanged(index);
 }
 
 void kamakura::on_actionOpen_triggered()
@@ -142,9 +145,12 @@ void kamakura::openFileByPath(const QString& path)
     int index = tabs->addTab(editor, fileInfo.fileName());
     tabs->setTabToolTip(index, path); 
     tabs->setCurrentIndex(index);
-    
+
     opened_docs_widget->addItem(fileInfo.fileName());
     syncListSelectionWithTab(index);
+
+    // Explicitly update highlighter in case currentChanged is not emitted
+    onCurrentTabChanged(index);
 }
 
 void kamakura::on_actionSave_triggered()


### PR DESCRIPTION
## Summary
- ensure syntax highlighter activates when creating a new file
- update syntax highlighter when a file is opened even if currentChanged is not emitted

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cf52e0c4832d8f4d81a15d8a7c19