### PR TITLE
Fix missing codeeditor.h during build

### DIFF
--- a/Kamakura.pro
+++ b/Kamakura.pro
@@ -6,6 +6,9 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 CONFIG += c++17
 
+# Ensure generated build files include headers in the src directory
+INCLUDEPATH += src
+
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0


### PR DESCRIPTION
## Summary
- ensure `src` headers are available during qmake builds

## Testing
- `qmake && make` *(fails: `qmake: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842d4884838832d8d92bb00017c51e2