### PR TITLE
Fix window icon path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,9 @@ int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
     kamakura w;
-    w.setWindowIcon(QIcon("resources/icon.ico"));
+    // Use the resource system so the application icon is bundled in the binary
+    // The path corresponds to the prefix defined in resources.qrc
+    w.setWindowIcon(QIcon(":/new/prefix1/resources/icon.ico"));
     w.show();
     return a.exec();
 }


### PR DESCRIPTION
## Summary
- use Qt resource system when setting window icon so icon is bundled in the executable

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d58bf4f4832d9b39241b8d71a53c