### PR TITLE
Add dark/light theme toggle and extra language highlighting

### DIFF
--- a/src/kamakura.cpp
+++ b/src/kamakura.cpp
@@ -10,7 +10,11 @@
 #include <QListWidget>
 #include <QDockWidget>
 #include <QMenu>
+#include <QActionGroup>
 #include <QMimeData>
+#include <QApplication>
+#include <QPalette>
+#include <QColor>
 #include <QDebug>
 #include <QStringListModel>
 #include <QCoreApplication>
@@ -28,11 +32,16 @@ kamakura::kamakura(QWidget *parent)
     // Load language files from the embedded Qt resources, using the correct prefix.
     highlighter = new Highlighter({":/new/prefix1/resources/phits_commands.xml",
                                    ":/new/prefix1/resources/python_lang.xml",
-                                   ":/new/prefix1/resources/cpp_lang.xml"}, this);
+                                   ":/new/prefix1/resources/cpp_lang.xml",
+                                   ":/new/prefix1/resources/rust_lang.xml",
+                                   ":/new/prefix1/resources/haskell_lang.xml",
+                                   ":/new/prefix1/resources/fortran_lang.xml",
+                                   ":/new/prefix1/resources/web_lang.xml"}, this);
 
     tabs = new QTabWidget(this);
     tabs->setMovable(true);
     tabs->setTabsClosable(true);
+    tabs->setFont(QFont("Sans Serif", 10));
     setCentralWidget(tabs);
     
     findDialog = new FindDialog(this);
@@ -55,11 +64,24 @@ void kamakura::setupDocks()
 {
     opened_docs_dock  = new QDockWidget("Opened Files", this);
     opened_docs_widget = new QListWidget(opened_docs_dock);
+    opened_docs_widget->setFont(QFont("Sans Serif", 10));
     opened_docs_dock->setWidget(opened_docs_widget);
     addDockWidget(Qt::RightDockWidgetArea, opened_docs_dock);
-    
+
     QMenu *viewMenu = menuBar()->addMenu(tr("&View"));
     viewMenu->addAction(opened_docs_dock->toggleViewAction());
+
+    QActionGroup* themeGroup = new QActionGroup(this);
+    QAction* lightTheme = viewMenu->addAction(tr("Light Theme"));
+    QAction* darkTheme = viewMenu->addAction(tr("Dark Theme"));
+    lightTheme->setCheckable(true);
+    darkTheme->setCheckable(true);
+    themeGroup->addAction(lightTheme);
+    themeGroup->addAction(darkTheme);
+    darkTheme->setChecked(true);
+
+    connect(lightTheme, &QAction::triggered, this, &kamakura::setLightTheme);
+    connect(darkTheme, &QAction::triggered, this, &kamakura::setDarkTheme);
 }
 
 void kamakura::setupConnections()
@@ -359,4 +381,28 @@ void kamakura::on_actionHowTo_triggered()
     QMessageBox::information(this, "How To",
         "Open a file (.inp, .i, .py) to see syntax highlighting and get code completion suggestions. "
         "More language definitions can be added by creating new XML files.");
+}
+
+void kamakura::setLightTheme()
+{
+    qApp->setPalette(qApp->style()->standardPalette());
+}
+
+void kamakura::setDarkTheme()
+{
+    qApp->setStyle("Fusion");
+    QPalette darkPalette;
+    darkPalette.setColor(QPalette::Window, QColor(53,53,53));
+    darkPalette.setColor(QPalette::WindowText, Qt::white);
+    darkPalette.setColor(QPalette::Base, QColor(42,42,42));
+    darkPalette.setColor(QPalette::AlternateBase, QColor(66,66,66));
+    darkPalette.setColor(QPalette::ToolTipBase, Qt::white);
+    darkPalette.setColor(QPalette::ToolTipText, Qt::white);
+    darkPalette.setColor(QPalette::Text, Qt::white);
+    darkPalette.setColor(QPalette::Button, QColor(53,53,53));
+    darkPalette.setColor(QPalette::ButtonText, Qt::white);
+    darkPalette.setColor(QPalette::BrightText, Qt::red);
+    darkPalette.setColor(QPalette::Highlight, QColor(142,45,197).lighter());
+    darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+    qApp->setPalette(darkPalette);
 }

--- a/src/kamakura.h
+++ b/src/kamakura.h
@@ -51,6 +51,9 @@ private slots:
     void on_actionKamakura_triggered();
     void on_actionHowTo_triggered();
 
+    void setLightTheme();
+    void setDarkTheme();
+
     // Internal Logic Slots
     void openFileByPath(const QString& path);
     void closeTab(int index);

--- a/src/kamakura.ui
+++ b/src/kamakura.ui
@@ -12,7 +12,7 @@
   </property>
   <property name="font">
    <font>
-    <pointsize>16</pointsize>
+    <pointsize>10</pointsize>
    </font>
   </property>
   <property name="windowTitle">
@@ -22,7 +22,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0">
@@ -36,7 +36,7 @@
         <property name="font">
          <font>
           <family>TeX Gyre Adventor</family>
-          <pointsize>14</pointsize>
+          <pointsize>10</pointsize>
          </font>
         </property>
        </widget>
@@ -57,14 +57,14 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+    <pointsize>10</pointsize>
     </font>
    </property>
    <widget class="QMenu" name="menuFile">
     <property name="font">
      <font>
       <family>TeX Gyre Adventor</family>
-      <pointsize>14</pointsize>
+      <pointsize>10</pointsize>
      </font>
     </property>
     <property name="title">
@@ -77,7 +77,7 @@
     <property name="font">
      <font>
       <family>TeX Gyre Adventor</family>
-      <pointsize>14</pointsize>
+      <pointsize>10</pointsize>
      </font>
     </property>
     <property name="title">
@@ -96,7 +96,7 @@
     <property name="font">
      <font>
       <family>TeX Gyre Adventor</family>
-      <pointsize>14</pointsize>
+      <pointsize>10</pointsize>
      </font>
     </property>
     <property name="title">
@@ -112,14 +112,14 @@
   <widget class="QStatusBar" name="statusbar">
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
   </widget>
   <widget class="QToolBar" name="toolBar">
    <property name="font">
     <font>
-     <pointsize>18</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="windowTitle">
@@ -160,7 +160,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -178,7 +178,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -196,7 +196,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -214,7 +214,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -232,7 +232,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -250,7 +250,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -268,7 +268,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -286,7 +286,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -304,7 +304,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -322,7 +322,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">
@@ -340,7 +340,7 @@
    <property name="font">
     <font>
      <family>TeX Gyre Adventor</family>
-     <pointsize>14</pointsize>
+     <pointsize>10</pointsize>
     </font>
    </property>
    <property name="shortcut">

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -19,5 +19,9 @@
         <file>resources/phits_commands.xml</file>
         <file>resources/python_lang.xml</file>
         <file>resources/cpp_lang.xml</file>
+        <file>resources/rust_lang.xml</file>
+        <file>resources/haskell_lang.xml</file>
+        <file>resources/fortran_lang.xml</file>
+        <file>resources/web_lang.xml</file>
     </qresource>
 </RCC>

--- a/src/resources/fortran_lang.xml
+++ b/src/resources/fortran_lang.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<languages>
+    <language extentions="(f90|f95)">
+        <single_comment expression="!.*$"></single_comment>
+        <keywords>
+            <keyword>program</keyword>
+            <keyword>subroutine</keyword>
+            <keyword>function</keyword>
+            <keyword>end</keyword>
+            <keyword>module</keyword>
+            <keyword>use</keyword>
+            <keyword>implicit</keyword>
+            <keyword>none</keyword>
+            <keyword>integer</keyword>
+            <keyword>real</keyword>
+            <keyword>double</keyword>
+            <keyword>precision</keyword>
+            <keyword>complex</keyword>
+            <keyword>logical</keyword>
+            <keyword>character</keyword>
+            <keyword>if</keyword>
+            <keyword>then</keyword>
+            <keyword>else</keyword>
+            <keyword>endif</keyword>
+            <keyword>do</keyword>
+            <keyword>enddo</keyword>
+            <keyword>select</keyword>
+            <keyword>case</keyword>
+        </keywords>
+    </language>
+</languages>

--- a/src/resources/haskell_lang.xml
+++ b/src/resources/haskell_lang.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<languages>
+    <language extentions="(hs)">
+        <single_comment expression="--[^\n]*"></single_comment>
+        <multiline_comment begin="\{-" end="-\}"></multiline_comment>
+        <keywords>
+            <keyword>module</keyword>
+            <keyword>where</keyword>
+            <keyword>import</keyword>
+            <keyword>data</keyword>
+            <keyword>type</keyword>
+            <keyword>newtype</keyword>
+            <keyword>deriving</keyword>
+            <keyword>class</keyword>
+            <keyword>instance</keyword>
+            <keyword>if</keyword>
+            <keyword>then</keyword>
+            <keyword>else</keyword>
+            <keyword>case</keyword>
+            <keyword>of</keyword>
+            <keyword>let</keyword>
+            <keyword>in</keyword>
+            <keyword>do</keyword>
+        </keywords>
+    </language>
+</languages>

--- a/src/resources/rust_lang.xml
+++ b/src/resources/rust_lang.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<languages>
+    <language extentions="(rs)">
+        <single_comment expression="//[^\n]*"></single_comment>
+        <multiline_comment begin="/\*" end="\*/"></multiline_comment>
+        <keywords>
+            <keyword>fn</keyword>
+            <keyword>let</keyword>
+            <keyword>mut</keyword>
+            <keyword>pub</keyword>
+            <keyword>crate</keyword>
+            <keyword>mod</keyword>
+            <keyword>use</keyword>
+            <keyword>struct</keyword>
+            <keyword>enum</keyword>
+            <keyword>trait</keyword>
+            <keyword>impl</keyword>
+            <keyword>for</keyword>
+            <keyword>while</keyword>
+            <keyword>loop</keyword>
+            <keyword>match</keyword>
+            <keyword>if</keyword>
+            <keyword>else</keyword>
+            <keyword>return</keyword>
+            <keyword>break</keyword>
+            <keyword>continue</keyword>
+        </keywords>
+    </language>
+</languages>

--- a/src/resources/web_lang.xml
+++ b/src/resources/web_lang.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<languages>
+    <language extentions="(html|htm)">
+        <multiline_comment begin="&lt;!--" end="--&gt;"></multiline_comment>
+        <keywords>
+            <keyword>html</keyword>
+            <keyword>head</keyword>
+            <keyword>body</keyword>
+            <keyword>div</keyword>
+            <keyword>span</keyword>
+            <keyword>script</keyword>
+            <keyword>style</keyword>
+            <keyword>link</keyword>
+            <keyword>meta</keyword>
+            <keyword>title</keyword>
+        </keywords>
+    </language>
+    <language extentions="(css)">
+        <multiline_comment begin="/\*" end="\*/"></multiline_comment>
+        <keywords>
+            <keyword>color</keyword>
+            <keyword>background</keyword>
+            <keyword>font-size</keyword>
+            <keyword>margin</keyword>
+            <keyword>padding</keyword>
+            <keyword>border</keyword>
+            <keyword>display</keyword>
+            <keyword>flex</keyword>
+        </keywords>
+    </language>
+</languages>


### PR DESCRIPTION
## Summary
- allow switching between dark and light themes from the *View* menu
- shrink UI fonts so filenames and explorer look normal
- add syntax files for Rust, Haskell, Fortran and HTML/CSS
- register new language files in the resources
- apply smaller fonts to tabs and opened-files list

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fd107d64832d94e0033437e6b152