### PR TITLE
Fix editor theme switching

### DIFF
--- a/src/codeeditor.cpp
+++ b/src/codeeditor.cpp
@@ -17,8 +17,7 @@ CodeEditor::CodeEditor(QWidget *parent) : QPlainTextEdit(parent)
 {
     lineNumberArea = new LineNumberArea(this);
 
-    // Dark background and foreground for editor
-    setStyleSheet("background-color:#2b2b2b;color:#ffffff;");
+    applyDarkTheme();
 
     connect(this, &CodeEditor::blockCountChanged, this, &CodeEditor::updateLineNumberAreaWidth);
     connect(this, &CodeEditor::updateRequest, this, &CodeEditor::updateLineNumberArea);
@@ -77,9 +76,7 @@ void CodeEditor::highlightCurrentLine()
     if (!isReadOnly()) {
         QTextEdit::ExtraSelection selection;
 
-        QColor lineColor = QColor("#333333");
-
-        selection.format.setBackground(lineColor);
+        selection.format.setBackground(lineHighlightColor);
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
         selection.cursor = textCursor();
         selection.cursor.clearSelection();
@@ -91,7 +88,7 @@ void CodeEditor::highlightCurrentLine()
 
 void CodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event) {
     QPainter painter(lineNumberArea);
-    painter.fillRect(event->rect(), QColor("#444444"));
+    painter.fillRect(event->rect(), lineNumberAreaBgColor);
     QTextBlock block = firstVisibleBlock();
     int blockNumber = block.blockNumber();
     int top = (int) blockBoundingGeometry(block).translated(contentOffset()).top();
@@ -100,7 +97,7 @@ void CodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event) {
     while (block.isValid() && top <= event->rect().bottom()) {
         if (block.isVisible() && bottom >= event->rect().top()) {
             QString number = QString::number(blockNumber + 1);
-            painter.setPen(QColor("#aaaaaa"));
+            painter.setPen(lineNumberAreaTextColor);
             painter.drawText(0, top, lineNumberArea->width(), fontMetrics().height(),
                              Qt::AlignRight, number);
         }
@@ -236,5 +233,25 @@ void CodeEditor::handleCursorPositionChanged()
     metrics.totalLines = blockCount();
     emit lineChanged(metrics.currentLine, metrics.totalLines);
     emit columnChanged(metrics.currentColumn);
+}
+
+void CodeEditor::applyLightTheme()
+{
+    setStyleSheet("background-color:#ffffff;color:#000000;");
+    lineHighlightColor = QColor("#e0e0e0");
+    lineNumberAreaBgColor = QColor("#f0f0f0");
+    lineNumberAreaTextColor = QColor("#555555");
+    highlightCurrentLine();
+    lineNumberArea->update();
+}
+
+void CodeEditor::applyDarkTheme()
+{
+    setStyleSheet("background-color:#2b2b2b;color:#ffffff;");
+    lineHighlightColor = QColor("#333333");
+    lineNumberAreaBgColor = QColor("#444444");
+    lineNumberAreaTextColor = QColor("#aaaaaa");
+    highlightCurrentLine();
+    lineNumberArea->update();
 }
 //Kamakura-- Mehrdad S. Beni and Hiroshi Watabe, Japan 2023

--- a/src/codeeditor.h
+++ b/src/codeeditor.h
@@ -11,6 +11,7 @@
 #include <QTextFormat>
 #include <QTextCursor>
 #include <QMessageBox>
+#include <QColor>
 #include "finddialog.h"
 #include "documentmetrics.h"
 
@@ -21,6 +22,9 @@ class CodeEditor : public QPlainTextEdit {
 
 public:
     CodeEditor(QWidget *parent = nullptr);
+
+    void applyLightTheme();
+    void applyDarkTheme();
 
     inline DocumentMetrics getDocumentMetrics() const { return metrics; }
 
@@ -65,6 +69,9 @@ private:
     QWidget *lineNumberArea;
      DocumentMetrics metrics;
      QString getFileNameFromPath();
+     QColor lineHighlightColor;
+     QColor lineNumberAreaBgColor;
+     QColor lineNumberAreaTextColor;
 
 };
 

--- a/src/kamakura.cpp
+++ b/src/kamakura.cpp
@@ -51,6 +51,8 @@ kamakura::kamakura(QWidget *parent)
     setupDocks();
     setupConnections();
 
+    setDarkTheme();
+
     on_actionNew_triggered(); // Start with a new, empty tab
     updateWindowTitle("");
 }
@@ -100,6 +102,11 @@ void kamakura::setupEditor(CodeEditor* editor)
     font.setFixedPitch(true);
     font.setPointSize(12);
     editor->setFont(font);
+
+    if (darkThemeEnabled)
+        editor->applyDarkTheme();
+    else
+        editor->applyLightTheme();
 
     connect(editor, &QPlainTextEdit::modificationChanged, this, &kamakura::updateTabDirtyStatus);
 }
@@ -385,7 +392,13 @@ void kamakura::on_actionHowTo_triggered()
 
 void kamakura::setLightTheme()
 {
+    darkThemeEnabled = false;
     qApp->setPalette(qApp->style()->standardPalette());
+    for (int i = 0; i < tabs->count(); ++i) {
+        if (auto editor = qobject_cast<CodeEditor*>(tabs->widget(i))) {
+            editor->applyLightTheme();
+        }
+    }
 }
 
 void kamakura::setDarkTheme()
@@ -404,5 +417,11 @@ void kamakura::setDarkTheme()
     darkPalette.setColor(QPalette::BrightText, Qt::red);
     darkPalette.setColor(QPalette::Highlight, QColor(142,45,197).lighter());
     darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+    darkThemeEnabled = true;
     qApp->setPalette(darkPalette);
+    for (int i = 0; i < tabs->count(); ++i) {
+        if (auto editor = qobject_cast<CodeEditor*>(tabs->widget(i))) {
+            editor->applyDarkTheme();
+        }
+    }
 }

--- a/src/kamakura.h
+++ b/src/kamakura.h
@@ -70,6 +70,8 @@ private:
     Highlighter* highlighter;
     FindDialog *findDialog;
     MetricReporter *metricReporter;
+
+    bool darkThemeEnabled{true};
     
     QDockWidget* opened_docs_dock;
     QListWidget* opened_docs_widget;


### PR DESCRIPTION
## Summary
- allow switching theme for existing editors
- add dark/light theme helpers in `CodeEditor`
- apply the correct theme when creating new editors

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ff4eb4d0832d8c3cae718e89fba9