### PR TITLE
Enhance FindDialog usability

### DIFF
--- a/src/codeeditor.cpp
+++ b/src/codeeditor.cpp
@@ -137,6 +137,28 @@ bool CodeEditor::find(QString query, bool caseSensitive, bool wholeWords)
     return matchFound;
 }
 
+bool CodeEditor::findBackward(QString query, bool caseSensitive, bool wholeWords)
+{
+    int cursorPositionBeforeCurrentSearch = textCursor().position();
+
+    QTextDocument::FindFlags searchOptions = getSearchOptionsFromFlags(caseSensitive, wholeWords);
+    searchOptions |= QTextDocument::FindBackward;
+
+    bool matchFound = QPlainTextEdit::find(query, searchOptions);
+
+    if (!matchFound)
+    {
+        moveCursor(QTextCursor::End);
+        matchFound = QPlainTextEdit::find(query, searchOptions);
+    }
+    if (!matchFound)
+    {
+        moveCursorTo(cursorPositionBeforeCurrentSearch);
+    }
+
+    return matchFound;
+}
+
 
 void CodeEditor::replace(QString what, QString with, bool caseSensitive, bool wholeWords)
 {

--- a/src/codeeditor.h
+++ b/src/codeeditor.h
@@ -61,6 +61,7 @@ private slots:
 
 public slots:
     bool find(QString query, bool caseSensitive, bool wholeWords);
+    bool findBackward(QString query, bool caseSensitive, bool wholeWords);
     void replace(QString what, QString with, bool caseSensitive, bool wholeWords);
     void replaceAll(QString what, QString with, bool caseSensitive, bool wholeWords);
     void updateMetrics();

--- a/src/finddialog.cpp
+++ b/src/finddialog.cpp
@@ -14,6 +14,8 @@ FindDialog::FindDialog(QWidget *parent)
 
 
     connect(FindKeywordButton, SIGNAL(clicked()), this, SLOT(on_FindKeywordButton_clicked()));
+    connect(FindBackwardButton, SIGNAL(clicked()), this, SLOT(on_FindBackwardButton_clicked()));
+    connect(exitButton, SIGNAL(clicked()), this, SLOT(on_exitButton_clicked()));
     connect(replaceButton, SIGNAL(clicked()), this, SLOT(on_replaceOperation_initiated()));
     connect(replaceAllButton, SIGNAL(clicked()), this, SLOT(on_replaceOperation_initiated()));
 }
@@ -28,6 +30,8 @@ FindDialog::~FindDialog()
     delete FindKeywordButton;
     delete replaceButton;
     delete replaceAllButton;
+    delete FindBackwardButton;
+    delete exitButton;
     delete findHorizontalLayout;
     delete replaceHorizontalLayout;
     delete optionsLayout;
@@ -37,7 +41,7 @@ FindDialog::~FindDialog()
 void FindDialog::initializeWidgets()
 {
     findLabel = new QLabel(tr("Keyword to search:    "));
-    QFont f( "Arial", 14, QFont::Normal);
+    QFont f( "Arial", 11, QFont::Normal);
     findLabel->setFont(f);
     //textLabel->setFont( f);
     //findLabel->setPixmap()
@@ -53,6 +57,10 @@ void FindDialog::initializeWidgets()
     replaceButton->setFont(f);
     replaceAllButton = new QPushButton(tr("&Replace all keywords"));
     replaceAllButton->setFont(f);
+    FindBackwardButton = new QPushButton(tr("&Find backward"));
+    FindBackwardButton->setFont(f);
+    exitButton = new QPushButton(tr("E&xit"));
+    exitButton->setFont(f);
 }
 
 
@@ -73,8 +81,10 @@ void FindDialog::initializeLayout()
     replaceHorizontalLayout->addWidget(replaceLineEdit);
 
     optionsLayout->addWidget(FindKeywordButton);
+    optionsLayout->addWidget(FindBackwardButton);
     optionsLayout->addWidget(replaceButton);
     optionsLayout->addWidget(replaceAllButton);
+    optionsLayout->addWidget(exitButton);
 
     setLayout(verticalLayout);
 }
@@ -92,6 +102,26 @@ void FindDialog::on_FindKeywordButton_clicked()
     bool caseSensitive = false;
     bool wholeWords = true;
     emit(startFinding(query, caseSensitive, wholeWords));
+}
+
+void FindDialog::on_FindBackwardButton_clicked()
+{
+    QString query = findLineEdit->text();
+
+    if (query.isEmpty())
+    {
+        QMessageBox::information(this, tr("No keyword"), tr("Please enter a keyword"));
+        return;
+    }
+
+    bool caseSensitive = false;
+    bool wholeWords = true;
+    emit(startFindingBackward(query, caseSensitive, wholeWords));
+}
+
+void FindDialog::on_exitButton_clicked()
+{
+    close();
 }
 
 

--- a/src/finddialog.h
+++ b/src/finddialog.h
@@ -24,12 +24,15 @@ public:
 signals:
 
     void startFinding(QString queryText, bool caseSensitive, bool wholeWords);
+    void startFindingBackward(QString queryText, bool caseSensitive, bool wholeWords);
     void startReplacing(QString what, QString with, bool caseSensitive, bool wholeWords);
     void startReplacingAll(QString what, QString with, bool caseSensitive, bool wholeWords);
 
 public slots:
 
     void on_FindKeywordButton_clicked();
+    void on_FindBackwardButton_clicked();
+    void on_exitButton_clicked();
     void on_replaceOperation_initiated();
     void onFindResultReady(QString message) { QMessageBox::information(this, "Search and Replace", message); }
 
@@ -41,8 +44,10 @@ private:
     QLabel *findLabel;
     QLabel *replaceLabel;
     QPushButton *FindKeywordButton;
+    QPushButton *FindBackwardButton;
     QPushButton *replaceButton;
     QPushButton *replaceAllButton;
+    QPushButton *exitButton;
     QLineEdit *findLineEdit;
     QLineEdit *replaceLineEdit;
     QHBoxLayout *findHorizontalLayout;

--- a/src/kamakura.cpp
+++ b/src/kamakura.cpp
@@ -283,11 +283,13 @@ void kamakura::onCurrentTabChanged(int index)
 
     
     disconnect(findDialog, &FindDialog::startFinding, nullptr, nullptr);
+    disconnect(findDialog, &FindDialog::startFindingBackward, nullptr, nullptr);
     disconnect(findDialog, &FindDialog::startReplacing, nullptr, nullptr);
     disconnect(findDialog, &FindDialog::startReplacingAll, nullptr, nullptr);
     disconnect(editor, &CodeEditor::findResultReady, nullptr, nullptr);
 
     connect(findDialog, &FindDialog::startFinding, editor, &CodeEditor::find);
+    connect(findDialog, &FindDialog::startFindingBackward, editor, &CodeEditor::findBackward);
     connect(findDialog, &FindDialog::startReplacing, editor, &CodeEditor::replace);
     connect(findDialog, &FindDialog::startReplacingAll, editor, &CodeEditor::replaceAll);
     connect(editor, &CodeEditor::findResultReady, findDialog, &FindDialog::onFindResultReady);


### PR DESCRIPTION
## Summary
- adjust font size for FindDialog widgets
- add backward search capability
- add Exit button
- wire up backward search in CodeEditor and main window

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ef40ec94832d93e1a9b2daa5599e