### PR TITLE
Add image embedding to code editor

### DIFF
--- a/src/codeeditor.h
+++ b/src/codeeditor.h
@@ -6,7 +6,9 @@
 #include <QTextBlock>
 #include <QPaintEvent>
 #include <QResizeEvent>
-#include <QPlainTextEdit>
+#include <QTextEdit>
+#include <QFileDialog>
+#include <QUuid>
 #include <QFont>
 #include <QTextFormat>
 #include <QTextCursor>
@@ -19,7 +21,7 @@
 #include "airequester.h"
 
 //Kamakura-- Mehrdad S. Beni and Hiroshi Watabe, Japan 2023
-class CodeEditor : public QPlainTextEdit {
+class CodeEditor : public QTextEdit {
     Q_OBJECT
 
 public:
@@ -81,6 +83,7 @@ public slots:
     void handleAskChatGPT();
     void handleAskGemini();
     void duplicateLine();
+    void insertImage();
 
 private:
     QWidget *lineNumberArea;

--- a/src/kamakura.cpp
+++ b/src/kamakura.cpp
@@ -200,7 +200,7 @@ void kamakura::setupEditor(CodeEditor* editor)
 
     editor->setLineNumbersVisible(lineNumbersEnabled);
 
-    connect(editor, &QPlainTextEdit::modificationChanged, this, &kamakura::updateTabDirtyStatus);
+    connect(editor, &QTextEdit::modificationChanged, this, &kamakura::updateTabDirtyStatus);
 }
 
 CodeEditor* kamakura::currentEditor()


### PR DESCRIPTION
## Summary
- switch CodeEditor from `QPlainTextEdit` to `QTextEdit`
- allow inserting images via context menu
- update connections for `QTextEdit`

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543bbe7f48832d9b1d75e08f37179b